### PR TITLE
Have attach behave the same way as exec

### DIFF
--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -241,7 +241,7 @@ class LXC
     #
     # @see lxc-attach
     def attach(*args)
-      self.exec("lxc-attach", *args)
+      self.exec("lxc-attach", "--", *args)
     end
 
     # Bootstrap a container


### PR DESCRIPTION
This PR should be pretty straightforward.

Before | AFTER
------------ | -------------
c.exec(cmd) | c.exec(cmd)
c.attach('--', cmd) | c.attach(cmd)
