### PR TITLE
[Feature] implemented lxc-snapshot command

### DIFF
--- a/lib/lxc/container.rb
+++ b/lib/lxc/container.rb
@@ -141,6 +141,16 @@ class LXC
       self.lxc.exec("lxc-clone", *args)
     end
 
+    # Operate a snapshot of the contaienr
+    #
+    # Runs the "lxc-snapshot" command.
+    #
+    # @return [Array<String>] Lines of output from the executed command.
+    # @see lxc-snapshot
+    def snapshot(*args)
+      self.lxc.exec("lxc-snapshot", *args)
+    end
+
     # Stop the container
     #
     # Runs the "lxc-stop" command.


### PR DESCRIPTION
Implemented [lxc-snapshot](https://linuxcontainers.org/lxc/manpages//man1/lxc-snapshot.1.html).
To create a snapshot of the container, this gem has only `lxc-clone`.
So I added this command to `container.rb`.